### PR TITLE
Make icon and border inline with iOS 14 style

### DIFF
--- a/lib/src/list_tile.dart
+++ b/lib/src/list_tile.dart
@@ -199,7 +199,7 @@ class CupertinoListTile extends StatelessWidget {
         child: trailing!,
       );
     } else {
-      trailingIcon = Icon(CupertinoIcons.right_chevron,
+      trailingIcon = Icon(CupertinoIcons.chevron_forward,
           color: CupertinoDynamicColor.resolve(
               CupertinoColors.separator, context));
     }
@@ -228,6 +228,7 @@ class CupertinoListTile extends StatelessWidget {
         decoration: BoxDecoration(
           border: Border(
             bottom: BorderSide(
+              width: 0.5,
               color: CupertinoDynamicColor.resolve(
                   CupertinoColors.separator, context),
             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cupertino_list_tile
 description: >-
   This is a Cupertino version of the stock Material ListTile in Flutter.
-version: 0.1.3
+version: 0.1.4
 homepage: https://github.com/jpnurmi/cupertino_list_tile
 repository: https://github.com/jpnurmi/cupertino_list_tile
 issue_tracker: https://github.com/jpnurmi/cupertino_list_tile/issues
@@ -9,7 +9,7 @@ issue_tracker: https://github.com/jpnurmi/cupertino_list_tile/issues
 environment:
   sdk: '>=2.7.0 <3.0.0'
 dependencies:
-  cupertino_icons: ^0.1.3
+  cupertino_icons: ">=1.0.0"
   flutter:
     sdk: flutter
 dev_dependencies:


### PR DESCRIPTION
Change the border to be slightly slimmer thus more sleek and make the trailing icon more compact just as in iOS 14. 
![image](https://user-images.githubusercontent.com/42590291/104807255-84377200-5792-11eb-8fb3-7fc8004941d3.png)
